### PR TITLE
Corrected typo in mods/tools/init.lua

### DIFF
--- a/mods/tools/init.lua
+++ b/mods/tools/init.lua
@@ -618,7 +618,7 @@ minetest.register_tool("tools:pick_bronze", {
 
 minetest.register_tool("tools:shovel_bronze", {
 	description = "Bronze Shovel",
-	inventory_image = "tool_bronzehovel.png^[transformR90",
+	inventory_image = "tool_bronzeshovel.png^[transformR90",
 	tool_capabilities = {
 		full_punch_interval = 1.67,
 		max_drop_level = 0,


### PR DESCRIPTION
Corrected typo in line 621 where `tool_bronzeshovel.png` incorrectly read `tool_bronzehovel.png` (without the "s") preventing the texture from loading.